### PR TITLE
Show warning if client doesn't exist FIXES #1

### DIFF
--- a/sensu-report
+++ b/sensu-report
@@ -76,6 +76,33 @@ def fetch_sensu_data(server, port, client, username, password):
     data = json.load(response)
     return data
 
+def check_client_exists(server, port, client, username, password):
+    """ Connects to the Sensu API over a given host and port, and returns
+    the http response code meaning we can determine if client exists. """
+    base_url = 'http://' + server + ':' + str(port)
+    api_url = base_url + '/clients/' + client
+    try:
+        if username:
+            password_mgr = urllib2.HTTPPasswordMgrWithDefaultRealm()
+            password_mgr.add_password(
+                realm=None,
+                uri=base_url,
+                user=username,
+                passwd=password)
+            auth_handler = urllib2.HTTPBasicAuthHandler(password_mgr)
+            opener = urllib2.build_opener(auth_handler)
+            urllib2.install_opener(opener)
+        response = urllib2.urlopen(api_url)
+    except urllib2.HTTPError, e:
+        return e.code
+    except:
+          print "Fetching the Sensu API Url didn't work:"
+          print api_url
+          raise
+    if response:
+      result = response.getcode()
+    return result
+
 
 def fetch_silence_data(server, port, client, username, password):
     """ Connects to the Sensu API over a given host and port, and returns
@@ -182,10 +209,12 @@ def print_line(entry, max_line_length):
     print
 
 
-def print_report(data, max_line_length):
+def print_report(data, max_line_length, http_code):
     """Prints a human readable report based on the sensu data"""
     print
-    if len(data) > 0:
+    # we only want to show events when client exists
+    if http_code == 200:
+      if len(data) > 0:
         print "Don't Panic! Ops already knows! Failed Sensu checks on this host:"
         # Criticals
         for entry in sorted([x for x in data if x['check']['status'] == 2]):
@@ -196,8 +225,10 @@ def print_report(data, max_line_length):
         # Unknown
         for entry in sorted([x for x in data if x['check']['status'] != 2 and x['check']['status'] != 1]):
             print_line(entry, max_line_length)
+      else:
+          print "All Sensu checks " + GREEN + "green " + CLEAR + "for this host."
     else:
-        print "All Sensu checks " + GREEN + "green " + CLEAR + "for this host."
+      print YELLOW + "This client" + CLEAR + " doesn't exist in Sensu"
     print
 
 
@@ -225,10 +256,13 @@ def main():
         options.server, options.port, options.client,
         options.user, options.password)
     print_silence_report(silence_data, options.max_line_length)
+    http_code = check_client_exists(
+        options.server, options.port, options.client,
+        options.user, options.password)
     events = fetch_sensu_data(
         options.server, options.port, options.client,
         options.user, options.password)
-    print_report(events, options.max_line_length)
+    print_report(events, options.max_line_length, http_code)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This should fix the issue with the report showing green when the client doesn't exist in sensu. Examples:

```
lbriggs@hostname[±|show_missing_client ✓]:~/github/sensu-report $ ./sensu-report -s <redacted> -p 4567 -U sensu -P <redacted> -c fakehost
This client doesn't exist in Sensu
```

and normal hosts working as usual:

```
lbriggs@hostname[±|show_missing_client ✓]:~/github/sensu-report $ ./sensu-report -s <redacted> -p 4567 -U sensu -P <redacted>

All Sensu checks green for this host.
```

Regarding the way I've done it, it definitely could be a lot nicer, but it works..
